### PR TITLE
Unify HTTP response streaming protocol for all response types

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
         cache-dependency-path: |
           tunnel/server/go.sum
           tunnel/agent/go.sum
+          tunnel/integration_test/go.sum
 
     - name: Build server
       run: cd tunnel/server && go build -v .
@@ -40,6 +41,9 @@ jobs:
 
     - name: Vet agent
       run: cd tunnel/agent && go vet ./...
+
+    - name: Integration tests
+      run: cd tunnel/integration_test && go test -v -timeout 90s ./...
 
   deploy:
     name: Deploy to Cloud Run

--- a/tunnel/agent/main.go
+++ b/tunnel/agent/main.go
@@ -18,6 +18,9 @@ import (
 )
 
 // Frame matches the server's JSON protocol.
+//
+// Unified protocol: all HTTP responses use response_start/response_data/response_end.
+// The agent doesn't distinguish between SSE, streaming, or regular HTTP — it just proxies.
 type Frame struct {
 	Type string `json:"type"`
 
@@ -26,7 +29,7 @@ type Frame struct {
 	Secret    string `json:"secret,omitempty"`
 	PublicURL string `json:"public_url,omitempty"`
 
-	// HTTP request
+	// HTTP request (server → agent)
 	ReqID   string            `json:"req_id,omitempty"`
 	Method  string            `json:"method,omitempty"`
 	Path    string            `json:"path,omitempty"`
@@ -34,14 +37,13 @@ type Frame struct {
 	Headers map[string]string `json:"headers,omitempty"`
 	Body    string            `json:"body,omitempty"`
 
-	// HTTP response
+	// HTTP response (agent → server) — unified streaming protocol
+	// response_start: Status + RespHeaders
+	// response_data:  Data (base64-encoded body chunk)
+	// response_end:   signals body complete
 	Status      int               `json:"status,omitempty"`
 	RespHeaders map[string]string `json:"resp_headers,omitempty"`
-	RespBody    string            `json:"resp_body,omitempty"`
-
-	// Streaming
-	Data string `json:"data,omitempty"`
-	Done bool   `json:"done,omitempty"`
+	Data        string            `json:"data,omitempty"`
 
 	// WebSocket forwarding
 	ConnID      string `json:"conn_id,omitempty"`
@@ -50,11 +52,13 @@ type Frame struct {
 }
 
 var (
-	serverAddr string
-	localAddr  string
-	tunnelID   string
-	secret     string
-	httpClient = &http.Client{Timeout: 30 * time.Second}
+	serverAddr  string
+	localAddr   string
+	tunnelID    string
+	secret      string
+	// No timeout — the server enforces timeouts. This lets SSE, chunked, and
+	// long-running responses stream for as long as the local service needs.
+	proxyClient = &http.Client{}
 )
 
 func main() {
@@ -181,6 +185,10 @@ func run() error {
 	}
 }
 
+// handleHTTPRequest is the unified HTTP proxy handler. It always streams the
+// response back using response_start/response_data/response_end frames. This
+// eliminates all special-casing for SSE, chunked, or regular HTTP responses —
+// the agent just proxies raw bytes from the local service.
 func handleHTTPRequest(ctx context.Context, conn *websocket.Conn, req Frame) {
 	url := localAddr + req.Path
 	if req.Query != "" {
@@ -210,86 +218,53 @@ func handleHTTPRequest(ctx context.Context, conn *websocket.Conn, req Frame) {
 		httpReq.Header.Set(k, v)
 	}
 
-	// Check if this should be streamed (SSE)
-	isSSE := strings.Contains(req.Headers["Accept"], "text/event-stream") ||
-		strings.Contains(req.Path, "/stream") ||
-		strings.Contains(req.Path, "/events")
-
-	if isSSE {
-		handleStreamingHTTP(ctx, conn, req.ReqID, httpReq)
-		return
-	}
-
-	resp, err := httpClient.Do(httpReq)
+	resp, err := proxyClient.Do(httpReq)
 	if err != nil {
 		sendError(ctx, conn, req.ReqID, 502, "local service error: "+err.Error())
 		return
 	}
 	defer resp.Body.Close()
 
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 8*1024*1024))
-
+	// Send response headers
 	headers := make(map[string]string)
 	for k, v := range resp.Header {
 		headers[k] = v[0]
 	}
 
-	frame := Frame{
-		Type:        "response",
+	startFrame := Frame{
+		Type:        "response_start",
 		ReqID:       req.ReqID,
 		Status:      resp.StatusCode,
 		RespHeaders: headers,
-		RespBody:    base64.StdEncoding.EncodeToString(respBody),
 	}
-	data, _ := json.Marshal(frame)
-	conn.Write(ctx, websocket.MessageText, data)
-}
-
-func handleStreamingHTTP(ctx context.Context, conn *websocket.Conn, reqID string, httpReq *http.Request) {
-	client := &http.Client{} // no timeout for streaming
-	resp, err := client.Do(httpReq)
-	if err != nil {
-		sendError(ctx, conn, reqID, 502, "local service error: "+err.Error())
+	data, _ := json.Marshal(startFrame)
+	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
 		return
 	}
-	defer resp.Body.Close()
 
-	headers := make(map[string]string)
-	for k, v := range resp.Header {
-		headers[k] = v[0]
-	}
-
-	// Send streaming start
-	start := Frame{
-		Type:        "streaming_start",
-		ReqID:       reqID,
-		Status:      resp.StatusCode,
-		RespHeaders: headers,
-	}
-	data, _ := json.Marshal(start)
-	conn.Write(ctx, websocket.MessageText, data)
-
-	// Stream chunks
+	// Stream response body in chunks
 	buf := make([]byte, 32*1024)
 	for {
 		n, err := resp.Body.Read(buf)
 		if n > 0 {
-			chunk := Frame{
-				Type:  "streaming_chunk",
-				ReqID: reqID,
-				Data:  string(buf[:n]),
+			dataFrame := Frame{
+				Type:  "response_data",
+				ReqID: req.ReqID,
+				Data:  base64.StdEncoding.EncodeToString(buf[:n]),
 			}
-			data, _ := json.Marshal(chunk)
-			conn.Write(ctx, websocket.MessageText, data)
+			d, _ := json.Marshal(dataFrame)
+			if writeErr := conn.Write(ctx, websocket.MessageText, d); writeErr != nil {
+				return
+			}
 		}
 		if err != nil {
 			break
 		}
 	}
 
-	// Send streaming end
-	end := Frame{Type: "streaming_end", ReqID: reqID}
-	data, _ = json.Marshal(end)
+	// Signal response complete
+	endFrame := Frame{Type: "response_end", ReqID: req.ReqID}
+	data, _ = json.Marshal(endFrame)
 	conn.Write(ctx, websocket.MessageText, data)
 }
 
@@ -354,14 +329,26 @@ func handleWSOpen(ctx context.Context, agentConn *websocket.Conn, frame Frame, w
 }
 
 func sendError(ctx context.Context, conn *websocket.Conn, reqID string, status int, msg string) {
-	frame := Frame{
-		Type:        "response",
+	// Errors use the same unified protocol: response_start + response_data + response_end
+	startFrame := Frame{
+		Type:        "response_start",
 		ReqID:       reqID,
 		Status:      status,
 		RespHeaders: map[string]string{"Content-Type": "text/plain"},
-		RespBody:    base64.StdEncoding.EncodeToString([]byte(msg)),
 	}
-	data, _ := json.Marshal(frame)
+	data, _ := json.Marshal(startFrame)
+	conn.Write(ctx, websocket.MessageText, data)
+
+	dataFrame := Frame{
+		Type:  "response_data",
+		ReqID: reqID,
+		Data:  base64.StdEncoding.EncodeToString([]byte(msg)),
+	}
+	data, _ = json.Marshal(dataFrame)
+	conn.Write(ctx, websocket.MessageText, data)
+
+	endFrame := Frame{Type: "response_end", ReqID: reqID}
+	data, _ = json.Marshal(endFrame)
 	conn.Write(ctx, websocket.MessageText, data)
 }
 

--- a/tunnel/integration_test/go.mod
+++ b/tunnel/integration_test/go.mod
@@ -1,0 +1,5 @@
+module tunnel-server/tunnel/integration_test
+
+go 1.24
+
+require nhooyr.io/websocket v1.8.17

--- a/tunnel/integration_test/go.sum
+++ b/tunnel/integration_test/go.sum
@@ -1,0 +1,2 @@
+nhooyr.io/websocket v1.8.17 h1:KEVeLJkUywCKVsnLIDlD/5gtayKp8VoCkksHCGGfT9Y=
+nhooyr.io/websocket v1.8.17/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/tunnel/integration_test/integration_test.go
+++ b/tunnel/integration_test/integration_test.go
@@ -1,0 +1,424 @@
+// Package integration_test validates the unified protocol proxy end-to-end.
+//
+// It starts three components:
+//  1. A test web app (regular HTTP, SSE, chunked, WebSocket endpoints)
+//  2. The tunnel server (built binary)
+//  3. The tunnel agent (built binary, connecting server → test web app)
+//
+// Then it sends requests through the tunnel and validates each response type
+// works correctly without any special-casing.
+package integration_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+// getFreePort returns an available TCP port.
+func getFreePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return port
+}
+
+// buildBinary compiles a Go module and returns the path to the binary.
+func buildBinary(t *testing.T, srcDir, name string) string {
+	t.Helper()
+	binPath := filepath.Join(t.TempDir(), name)
+	cmd := exec.Command("go", "build", "-o", binPath, ".")
+	cmd.Dir = srcDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build %s failed: %v\n%s", name, err, out)
+	}
+	return binPath
+}
+
+// startTestApp starts a local HTTP server with various endpoint types.
+func startTestApp(t *testing.T, port int) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	// Regular HTTP endpoint
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Custom-Header", "test-value")
+		json.NewEncoder(w).Encode(map[string]string{"message": "hello world"})
+	})
+
+	// POST endpoint — echoes body back
+	mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", r.Header.Get("Content-Type"))
+		io.Copy(w, r.Body)
+	})
+
+	// SSE endpoint — sends 5 events then closes
+	mux.HandleFunc("/sse", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming not supported", 500)
+			return
+		}
+		w.WriteHeader(200)
+		flusher.Flush()
+
+		for i := 0; i < 5; i++ {
+			fmt.Fprintf(w, "data: event-%d\n\n", i)
+			flusher.Flush()
+			time.Sleep(50 * time.Millisecond)
+		}
+	})
+
+	// Chunked endpoint — sends multiple chunks
+	mux.HandleFunc("/chunked", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming not supported", 500)
+			return
+		}
+		for i := 0; i < 3; i++ {
+			fmt.Fprintf(w, "chunk-%d\n", i)
+			flusher.Flush()
+			time.Sleep(50 * time.Millisecond)
+		}
+	})
+
+	// Large response endpoint — tests multi-chunk body relay
+	mux.HandleFunc("/large", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		// Send 100KB of data (larger than the 32KB chunk size)
+		data := strings.Repeat("X", 100*1024)
+		w.Write([]byte(data))
+	})
+
+	// WebSocket endpoint — echoes messages back with prefix
+	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+
+		ctx := r.Context()
+		for {
+			msgType, msg, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+			reply := "echo:" + string(msg)
+			if err := conn.Write(ctx, msgType, []byte(reply)); err != nil {
+				return
+			}
+		}
+	})
+
+	// 404 handler
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: mux,
+	}
+	go srv.ListenAndServe()
+	t.Cleanup(func() {
+		srv.Close()
+	})
+}
+
+// waitForReady polls a URL until it returns 200 or the timeout expires.
+func waitForReady(url string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == 200 {
+				return nil
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("timeout waiting for %s", url)
+}
+
+func TestIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	projectRoot := ".."
+
+	// Build server and agent binaries first — avoids `go run` subprocess issues
+	// with process cleanup (WaitDelay, orphaned child processes).
+	t.Log("Building server and agent binaries...")
+	serverBin := buildBinary(t, projectRoot+"/server", "server")
+	agentBin := buildBinary(t, projectRoot+"/agent", "agent")
+	t.Log("Binaries built successfully")
+
+	// Allocate ports
+	appPort := getFreePort(t)
+	serverPort := getFreePort(t)
+
+	serverURL := fmt.Sprintf("http://127.0.0.1:%d", serverPort)
+	localURL := fmt.Sprintf("http://127.0.0.1:%d", appPort)
+
+	// 1. Start test web app
+	startTestApp(t, appPort)
+	if err := waitForReady(localURL+"/hello", 5*time.Second); err != nil {
+		t.Fatalf("test app failed to start: %v", err)
+	}
+	t.Log("Test app started on", localURL)
+
+	// 2. Start tunnel server
+	serverCmd := exec.Command(serverBin)
+	serverCmd.Env = append(os.Environ(),
+		fmt.Sprintf("PORT=%d", serverPort),
+		fmt.Sprintf("SERVER_URL=%s", serverURL),
+	)
+	serverCmd.Stdout = os.Stdout
+	serverCmd.Stderr = os.Stderr
+	if err := serverCmd.Start(); err != nil {
+		t.Fatalf("server start failed: %v", err)
+	}
+	t.Cleanup(func() {
+		serverCmd.Process.Signal(syscall.SIGTERM)
+		serverCmd.Process.Kill()
+		serverCmd.Wait()
+	})
+	if err := waitForReady(serverURL+"/__health__", 5*time.Second); err != nil {
+		t.Fatalf("server failed to start: %v", err)
+	}
+	t.Log("Tunnel server started on", serverURL)
+
+	// 3. Start tunnel agent — capture stdout to get the public URL
+	agentCmd := exec.Command(agentBin,
+		"--server", serverURL,
+		"--local", localURL,
+	)
+	agentStdout, _ := agentCmd.StdoutPipe()
+	agentCmd.Stderr = os.Stderr
+	if err := agentCmd.Start(); err != nil {
+		t.Fatalf("agent start failed: %v", err)
+	}
+	t.Cleanup(func() {
+		agentCmd.Process.Signal(syscall.SIGTERM)
+		agentCmd.Process.Kill()
+		agentCmd.Wait()
+	})
+
+	// Parse agent output to find the public URL.
+	// The goroutine keeps draining stdout so cmd.Wait() doesn't hang on pipe I/O.
+	var publicURL string
+	scanner := bufio.NewScanner(agentStdout)
+	urlCh := make(chan string, 1)
+	go func() {
+		for scanner.Scan() {
+			line := scanner.Text()
+			trimmed := strings.TrimSpace(line)
+			if strings.Contains(trimmed, "/__pub__/") && strings.HasPrefix(trimmed, "http") {
+				select {
+				case urlCh <- trimmed:
+				default:
+				}
+			}
+		}
+	}()
+
+	select {
+	case publicURL = <-urlCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for agent to print public URL")
+	}
+
+	t.Logf("Agent registered, public URL: %s", publicURL)
+
+	// Give the tunnel a moment to stabilize
+	time.Sleep(500 * time.Millisecond)
+
+	// --- Run tests ---
+
+	t.Run("regular_http_get", func(t *testing.T) {
+		resp, err := http.Get(publicURL + "hello")
+		if err != nil {
+			t.Fatalf("GET /hello failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+		if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+			t.Fatalf("expected Content-Type application/json, got %s", ct)
+		}
+		if hdr := resp.Header.Get("X-Custom-Header"); hdr != "test-value" {
+			t.Fatalf("expected X-Custom-Header=test-value, got %s", hdr)
+		}
+
+		var body map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["message"] != "hello world" {
+			t.Fatalf("expected 'hello world', got '%s'", body["message"])
+		}
+	})
+
+	t.Run("http_post_echo", func(t *testing.T) {
+		payload := `{"key":"value","number":42}`
+		resp, err := http.Post(publicURL+"echo", "application/json", strings.NewReader(payload))
+		if err != nil {
+			t.Fatalf("POST /echo failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		if string(bodyBytes) != payload {
+			t.Fatalf("expected echoed payload, got '%s'", string(bodyBytes))
+		}
+	})
+
+	t.Run("sse_streaming", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", publicURL+"sse", nil)
+		req.Header.Set("Accept", "text/event-stream")
+		client := &http.Client{Timeout: 30 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("GET /sse failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+		if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+			t.Fatalf("expected Content-Type text/event-stream, got %s", ct)
+		}
+
+		// Read all SSE events
+		body, _ := io.ReadAll(resp.Body)
+		content := string(body)
+		for i := 0; i < 5; i++ {
+			expected := fmt.Sprintf("data: event-%d", i)
+			if !strings.Contains(content, expected) {
+				t.Fatalf("missing SSE event %d in response: %s", i, content)
+			}
+		}
+	})
+
+	t.Run("chunked_response", func(t *testing.T) {
+		resp, err := http.Get(publicURL + "chunked")
+		if err != nil {
+			t.Fatalf("GET /chunked failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		content := string(body)
+		for i := 0; i < 3; i++ {
+			expected := fmt.Sprintf("chunk-%d", i)
+			if !strings.Contains(content, expected) {
+				t.Fatalf("missing chunk %d in response: %s", i, content)
+			}
+		}
+	})
+
+	t.Run("large_response", func(t *testing.T) {
+		resp, err := http.Get(publicURL + "large")
+		if err != nil {
+			t.Fatalf("GET /large failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		expected := 100 * 1024
+		if len(body) != expected {
+			t.Fatalf("expected %d bytes, got %d", expected, len(body))
+		}
+	})
+
+	t.Run("websocket_echo", func(t *testing.T) {
+		wsURL := strings.Replace(publicURL, "http://", "ws://", 1) + "ws"
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		conn, _, err := websocket.Dial(ctx, wsURL, nil)
+		if err != nil {
+			t.Fatalf("WebSocket dial failed: %v", err)
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+
+		// Wait for the agent to establish the local WS connection.
+		// The server sends ws_open to the agent which then dials the local
+		// service — this takes a moment.
+		time.Sleep(500 * time.Millisecond)
+
+		// Send and receive 3 messages
+		for i := 0; i < 3; i++ {
+			msg := fmt.Sprintf("test-message-%d", i)
+			if err := conn.Write(ctx, websocket.MessageText, []byte(msg)); err != nil {
+				t.Fatalf("WS write failed: %v", err)
+			}
+
+			_, reply, err := conn.Read(ctx)
+			if err != nil {
+				t.Fatalf("WS read failed: %v", err)
+			}
+
+			expected := "echo:" + msg
+			if string(reply) != expected {
+				t.Fatalf("expected '%s', got '%s'", expected, string(reply))
+			}
+		}
+	})
+
+	t.Run("404_passthrough", func(t *testing.T) {
+		resp, err := http.Get(publicURL + "nonexistent-path")
+		if err != nil {
+			t.Fatalf("GET /nonexistent-path failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 404 {
+			t.Fatalf("expected 404, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/tunnel/server/main.go
+++ b/tunnel/server/main.go
@@ -20,6 +20,9 @@ import (
 // --- Types ---
 
 // Frame types exchanged between server and agent over WebSocket.
+//
+// Unified protocol: all HTTP responses use response_start/response_data/response_end.
+// The agent doesn't distinguish between SSE, streaming, or regular HTTP — it just proxies.
 type Frame struct {
 	Type string `json:"type"`
 
@@ -36,16 +39,13 @@ type Frame struct {
 	Headers map[string]string `json:"headers,omitempty"`
 	Body    string            `json:"body,omitempty"`
 
-	// HTTP response (agent → server)
-	Status     int               `json:"status,omitempty"`
+	// HTTP response (agent → server) — unified streaming protocol
+	// response_start: Status + RespHeaders
+	// response_data:  Data (base64-encoded body chunk)
+	// response_end:   signals body complete
+	Status      int               `json:"status,omitempty"`
 	RespHeaders map[string]string `json:"resp_headers,omitempty"`
-	RespBody   string            `json:"resp_body,omitempty"`
-
-	// Streaming
-	ChunkIndex  int    `json:"chunk_index,omitempty"`
-	TotalChunks int    `json:"total_chunks,omitempty"`
-	Data        string `json:"data,omitempty"`
-	Done        bool   `json:"done,omitempty"`
+	Data        string            `json:"data,omitempty"`
 
 	// WebSocket forwarding
 	ConnID      string `json:"conn_id,omitempty"`
@@ -193,13 +193,13 @@ func handleAgentWS(w http.ResponseWriter, r *http.Request) {
 		}
 
 		switch frame.Type {
-		case "response":
+		case "response_start", "response_data", "response_end":
 			if ch, ok := tunnel.Pending.Load(frame.ReqID); ok {
-				ch.(chan *Frame) <- &frame
-			}
-		case "streaming_start", "streaming_chunk", "streaming_end":
-			if ch, ok := tunnel.Pending.Load(frame.ReqID); ok {
-				ch.(chan *Frame) <- &frame
+				select {
+				case ch.(chan *Frame) <- &frame:
+				default:
+					log.Printf("Agent %s: dropping frame for req %s (channel full)", id, frame.ReqID)
+				}
 			}
 		case "ws_data":
 			if ch, ok := tunnel.WSConns.Load(frame.ConnID); ok {
@@ -320,13 +320,8 @@ func handlePublic(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if this is a streaming request (SSE)
-	if isStreamingRequest(r, fwdPath) {
-		handleStreamingRequest(w, r, tunnel, fwdPath)
-		return
-	}
-
-	// Regular HTTP request
+	// All HTTP requests (regular, SSE, streaming) go through the same unified handler.
+	// The agent streams response bytes back regardless of response type.
 	handleHTTPRequest(w, r, tunnel, fwdPath)
 }
 
@@ -334,14 +329,7 @@ func isWebSocketUpgrade(r *http.Request) bool {
 	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket")
 }
 
-func isStreamingRequest(r *http.Request, path string) bool {
-	accept := r.Header.Get("Accept")
-	return strings.Contains(accept, "text/event-stream") ||
-		strings.Contains(path, "/stream") ||
-		strings.Contains(path, "/events")
-}
-
-// --- Regular HTTP proxying ---
+// --- Unified HTTP proxying ---
 
 func handleHTTPRequest(w http.ResponseWriter, r *http.Request, t *Tunnel, path string) {
 	reqID := uuid.New().String()[:8]
@@ -373,60 +361,6 @@ func handleHTTPRequest(w http.ResponseWriter, r *http.Request, t *Tunnel, path s
 		Body:    body,
 	}
 
-	ch := make(chan *Frame, 1)
-	t.Pending.Store(reqID, ch)
-	defer t.Pending.Delete(reqID)
-
-	data, _ := json.Marshal(frame)
-	t.Mu.Lock()
-	err := t.Conn.Write(r.Context(), websocket.MessageText, data)
-	t.Mu.Unlock()
-	if err != nil {
-		http.Error(w, "agent unreachable", http.StatusBadGateway)
-		return
-	}
-
-	// Wait for response
-	select {
-	case resp := <-ch:
-		respBody, _ := base64.StdEncoding.DecodeString(resp.RespBody)
-		for k, v := range resp.RespHeaders {
-			// Skip Content-Length — let Go recalculate after base64 decode
-			if strings.EqualFold(k, "Content-Length") {
-				continue
-			}
-			w.Header().Set(k, v)
-		}
-		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(respBody)))
-		w.WriteHeader(resp.Status)
-		w.Write(respBody)
-	case <-time.After(30 * time.Second):
-		http.Error(w, "timeout waiting for agent", http.StatusGatewayTimeout)
-	case <-r.Context().Done():
-	}
-}
-
-// --- Streaming (SSE) proxying ---
-
-func handleStreamingRequest(w http.ResponseWriter, r *http.Request, t *Tunnel, path string) {
-	reqID := uuid.New().String()[:8]
-
-	headers := make(map[string]string)
-	for k, v := range r.Header {
-		if !hopHeaders[k] {
-			headers[k] = v[0]
-		}
-	}
-
-	frame := Frame{
-		Type:    "request",
-		ReqID:   reqID,
-		Method:  r.Method,
-		Path:    path,
-		Query:   r.URL.RawQuery,
-		Headers: headers,
-	}
-
 	ch := make(chan *Frame, 64)
 	t.Pending.Store(reqID, ch)
 	defer t.Pending.Delete(reqID)
@@ -440,13 +374,14 @@ func handleStreamingRequest(w http.ResponseWriter, r *http.Request, t *Tunnel, p
 		return
 	}
 
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "streaming not supported", http.StatusInternalServerError)
-		return
-	}
-
+	// Unified response relay: receive response_start, then stream response_data
+	// chunks, then response_end. Works identically for regular HTTP, SSE, and
+	// chunked responses — the agent just proxies bytes from the local service.
+	flusher, _ := w.(http.Flusher)
 	headersWritten := false
+	timeout := time.NewTimer(30 * time.Second)
+	defer timeout.Stop()
+
 	for {
 		select {
 		case frame := <-ch:
@@ -454,34 +389,39 @@ func handleStreamingRequest(w http.ResponseWriter, r *http.Request, t *Tunnel, p
 				return
 			}
 			switch frame.Type {
-			case "streaming_start":
+			case "response_start":
 				for k, v := range frame.RespHeaders {
 					w.Header().Set(k, v)
 				}
 				w.WriteHeader(frame.Status)
-				flusher.Flush()
 				headersWritten = true
-			case "streaming_chunk":
+				if flusher != nil {
+					flusher.Flush()
+				}
+				timeout.Reset(60 * time.Second)
+
+			case "response_data":
 				if !headersWritten {
-					w.Header().Set("Content-Type", "text/event-stream")
 					w.WriteHeader(200)
 					headersWritten = true
 				}
-				w.Write([]byte(frame.Data))
-				flusher.Flush()
-			case "streaming_end":
-				return
-			case "response":
-				// Non-streaming fallback
-				for k, v := range frame.RespHeaders {
-					w.Header().Set(k, v)
+				chunk, _ := base64.StdEncoding.DecodeString(frame.Data)
+				w.Write(chunk)
+				if flusher != nil {
+					flusher.Flush()
 				}
-				w.WriteHeader(frame.Status)
-				w.Write([]byte(frame.RespBody))
+				timeout.Reset(60 * time.Second)
+
+			case "response_end":
 				return
 			}
-		case <-time.After(60 * time.Second):
+
+		case <-timeout.C:
+			if !headersWritten {
+				http.Error(w, "timeout waiting for agent", http.StatusGatewayTimeout)
+			}
 			return
+
 		case <-r.Context().Done():
 			return
 		}


### PR DESCRIPTION
## Summary
Consolidates the tunnel protocol to use a single unified streaming mechanism for all HTTP responses (regular, SSE, and chunked), eliminating special-case handling and simplifying the codebase.

## Key Changes

**Protocol Unification:**
- Replaced separate `response`, `streaming_start`/`streaming_chunk`/`streaming_end`, and `streaming_end` frame types with a unified three-frame pattern: `response_start` → `response_data` (repeating) → `response_end`
- All response bodies are now base64-encoded in `response_data` frames for consistent binary-safe transmission
- Removed `RespBody`, `ChunkIndex`, `TotalChunks`, and `Done` fields from Frame struct; consolidated to `Data` field

**Server-side (`tunnel/server/main.go`):**
- Removed `isStreamingRequest()` detection logic and `handleStreamingRequest()` function
- Merged streaming and regular HTTP handling into single `handleHTTPRequest()` function
- Updated frame type matching to handle `response_start`, `response_data`, `response_end` with non-blocking channel sends (drops frames if channel full rather than blocking)
- Unified response relay logic to handle all response types identically, with optional flushing for streaming clients
- Improved timeout handling with per-frame resets (60s between frames after headers sent)

**Agent-side (`tunnel/agent/main.go`):**
- Removed `handleStreamingHTTP()` function; all HTTP requests now use unified streaming
- Removed SSE detection logic (`isSSE` check)
- Changed `httpClient` to `proxyClient` with no timeout (server enforces timeouts, allowing long-running responses)
- Updated `handleHTTPRequest()` to always stream response in chunks using the unified protocol
- Updated `sendError()` to use the same three-frame pattern for error responses

## Implementation Details

- Response bodies are streamed in 32KB chunks from the local service, base64-encoded for safe transmission
- The agent no longer distinguishes between response types—it simply proxies raw bytes from the local service
- Server-side flushing is now optional (checks for `http.Flusher` support) to support both streaming and regular HTTP clients
- Timeout handling improved: 30s initial timeout, then 60s between frames to accommodate slow services
- Non-blocking channel sends on server prevent agent frame drops from blocking the WebSocket read loop

https://claude.ai/code/session_01VKi3uJHSgaHqoEbWhUaEY5